### PR TITLE
Importação do Positioning não é mais realizada através do positioning,

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,6 @@
     }
   },
   "dependencies": {
-    "positioning": "^1.3.1"
+    "ng-bootstrap": "^1.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgebr/angular-confirmation-popover",
-  "version": "3.4.4",
+  "version": "3.4.6",
   "description": "An angular 4.0+ bootstrap confirmation popover",
   "main": "./dist/umd/angular-confirmation-popover.js",
   "module": "./dist/esm/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgebr/angular-confirmation-popover",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "description": "An angular 4.0+ bootstrap confirmation popover",
   "main": "./dist/umd/angular-confirmation-popover.js",
   "module": "./dist/esm/src/index.js",
@@ -104,6 +104,6 @@
     }
   },
   "dependencies": {
-    "ng-bootstrap": "^1.6.3"
+    "ngx-bootstrap": "^2.0.3"
   }
 }

--- a/src/confirmationPopover.directive.ts
+++ b/src/confirmationPopover.directive.ts
@@ -19,10 +19,10 @@ import {
   TemplateRef,
   ComponentFactory
 } from '@angular/core';
-import {DOCUMENT} from '@angular/platform-browser';
-import {ConfirmationPopoverWindow} from './confirmationPopoverWindow.component';
-import {ConfirmationPopoverOptions, ConfirmationPopoverWindowOptions} from './confirmationPopoverOptions.provider';
-import { Positioning } from 'ng-bootstrap';
+import { DOCUMENT } from '@angular/platform-browser';
+import { ConfirmationPopoverWindow } from './confirmationPopoverWindow.component';
+import { ConfirmationPopoverOptions, ConfirmationPopoverWindowOptions } from './confirmationPopoverOptions.provider';
+import { Positioning } from 'ngx-bootstrap';
 
 /**
  * @private

--- a/src/confirmationPopover.directive.ts
+++ b/src/confirmationPopover.directive.ts
@@ -22,7 +22,7 @@ import {
 import {DOCUMENT} from '@angular/platform-browser';
 import {ConfirmationPopoverWindow} from './confirmationPopoverWindow.component';
 import {ConfirmationPopoverOptions, ConfirmationPopoverWindowOptions} from './confirmationPopoverOptions.provider';
-import {Positioning} from 'positioning';
+import { Positioning } from 'ng-bootstrap';
 
 /**
  * @private

--- a/src/confirmationPopover.module.ts
+++ b/src/confirmationPopover.module.ts
@@ -1,10 +1,10 @@
 import {NgModule, ModuleWithProviders, InjectionToken} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {Positioning} from 'positioning';
 import {ConfirmationPopover} from './confirmationPopover.directive';
 import {ConfirmationPopoverWindow} from './confirmationPopoverWindow.component';
 import {Focus} from './focus.directive';
 import {ConfirmationPopoverOptions, ConfirmationPopoverOptionsInterface} from './confirmationPopoverOptions.provider';
+import { Positioning } from 'ng-bootstrap';
 
 export const USER_OPTIONS: InjectionToken<string> = new InjectionToken('confirmation popover user options');
 

--- a/src/confirmationPopover.module.ts
+++ b/src/confirmationPopover.module.ts
@@ -4,7 +4,7 @@ import {ConfirmationPopover} from './confirmationPopover.directive';
 import {ConfirmationPopoverWindow} from './confirmationPopoverWindow.component';
 import {Focus} from './focus.directive';
 import {ConfirmationPopoverOptions, ConfirmationPopoverOptionsInterface} from './confirmationPopoverOptions.provider';
-import { Positioning } from 'ng-bootstrap';
+import { Positioning } from 'ngx-bootstrap';
 
 export const USER_OPTIONS: InjectionToken<string> = new InjectionToken('confirmation popover user options');
 

--- a/test/angular-confirmation-popover.spec.ts
+++ b/test/angular-confirmation-popover.spec.ts
@@ -21,7 +21,7 @@ import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
-import {Positioning} from 'ng-bootstrap';
+import {Positioning} from 'ngx-bootstrap';
 import {ConfirmationPopoverModule} from '../src';
 import {ConfirmationPopover} from '../src/confirmationPopover.directive';
 import {ConfirmationPopoverWindow} from '../src/confirmationPopoverWindow.component';

--- a/test/angular-confirmation-popover.spec.ts
+++ b/test/angular-confirmation-popover.spec.ts
@@ -21,7 +21,7 @@ import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
-import {Positioning} from 'positioning';
+import {Positioning} from 'ng-bootstrap';
 import {ConfirmationPopoverModule} from '../src';
 import {ConfirmationPopover} from '../src/confirmationPopover.directive';
 import {ConfirmationPopoverWindow} from '../src/confirmationPopoverWindow.component';


### PR DESCRIPTION
mas pelo ng-bootstrap. Foi necessário para a importação do
pocoweb-components funcionar corretamente